### PR TITLE
Add runner for Jest 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This is a patched version of [`jest-runner`](https://github.com/facebook/jest/tr
 
 ## Usage
 
-Install the runner with npm or Yarn. Make sure you install the version that corresponds to your Jest version. For example, if you are using Jest 27:
+Install the runner with npm or Yarn. Make sure you install the version that corresponds to your Jest version. For example, if you are using Jest 28:
 
 ```sh
-npm i -D jest-runner-iansu@27
+npm i -D jest-runner-iansu@28
 ```
 
 ```sh
-yarn add --dev jest-runner-iansu@27
+yarn add --dev jest-runner-iansu@28
 ```
 
 Add this line to your Jest config:

--- a/packages/jest-28/LICENSE
+++ b/packages/jest-28/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/jest-28/build/index.d.ts
+++ b/packages/jest-28/build/index.d.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {Config} from '@jest/types';
+import type {SerializableError} from '@jest/test-result';
+import {Test} from '@jest/test-result';
+import {TestEvents} from '@jest/test-result';
+import type {TestResult} from '@jest/test-result';
+import {TestWatcher} from 'jest-watcher';
+
+declare abstract class BaseTestRunner {
+  protected readonly _globalConfig: Config.GlobalConfig;
+  protected readonly _context: TestRunnerContext;
+  readonly isSerial?: boolean;
+  abstract readonly supportsEventEmitters: boolean;
+  constructor(_globalConfig: Config.GlobalConfig, _context: TestRunnerContext);
+}
+
+export declare abstract class CallbackTestRunner
+  extends BaseTestRunner
+  implements CallbackTestRunnerInterface
+{
+  readonly supportsEventEmitters = false;
+  abstract runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    onStart: OnTestStart,
+    onResult: OnTestSuccess,
+    onFailure: OnTestFailure,
+    options: TestRunnerOptions,
+  ): Promise<void>;
+}
+
+export declare interface CallbackTestRunnerInterface {
+  readonly isSerial?: boolean;
+  readonly supportsEventEmitters?: boolean;
+  runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    onStart: OnTestStart,
+    onResult: OnTestSuccess,
+    onFailure: OnTestFailure,
+    options: TestRunnerOptions,
+  ): Promise<void>;
+}
+
+export {Config};
+
+export declare abstract class EmittingTestRunner
+  extends BaseTestRunner
+  implements EmittingTestRunnerInterface
+{
+  readonly supportsEventEmitters = true;
+  abstract runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    options: TestRunnerOptions,
+  ): Promise<void>;
+  abstract on<Name extends keyof TestEvents>(
+    eventName: Name,
+    listener: (eventData: TestEvents[Name]) => void | Promise<void>,
+  ): UnsubscribeFn;
+}
+
+export declare interface EmittingTestRunnerInterface {
+  readonly isSerial?: boolean;
+  readonly supportsEventEmitters: true;
+  runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    options: TestRunnerOptions,
+  ): Promise<void>;
+  on<Name extends keyof TestEvents>(
+    eventName: Name,
+    listener: (eventData: TestEvents[Name]) => void | Promise<void>,
+  ): UnsubscribeFn;
+}
+
+export declare type JestTestRunner = CallbackTestRunner | EmittingTestRunner;
+
+export declare type OnTestFailure = (
+  test: Test,
+  serializableError: SerializableError,
+) => Promise<void>;
+
+export declare type OnTestStart = (test: Test) => Promise<void>;
+
+export declare type OnTestSuccess = (
+  test: Test,
+  testResult: TestResult,
+) => Promise<void>;
+
+export {Test};
+
+export {TestEvents};
+
+declare class TestRunner extends EmittingTestRunner {
+  #private;
+  runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    options: TestRunnerOptions,
+  ): Promise<void>;
+  on<Name extends keyof TestEvents>(
+    eventName: Name,
+    listener: (eventData: TestEvents[Name]) => void | Promise<void>,
+  ): UnsubscribeFn;
+}
+export default TestRunner;
+
+export declare type TestRunnerContext = {
+  changedFiles?: Set<string>;
+  sourcesRelatedToTestsInChangedFiles?: Set<string>;
+};
+
+export declare type TestRunnerOptions = {
+  serial: boolean;
+};
+
+export {TestWatcher};
+
+export declare type UnsubscribeFn = () => void;
+
+export {};

--- a/packages/jest-28/build/index.js
+++ b/packages/jest-28/build/index.js
@@ -1,0 +1,330 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+Object.defineProperty(exports, 'CallbackTestRunner', {
+  enumerable: true,
+  get: function () {
+    return _types.CallbackTestRunner;
+  }
+});
+Object.defineProperty(exports, 'EmittingTestRunner', {
+  enumerable: true,
+  get: function () {
+    return _types.EmittingTestRunner;
+  }
+});
+exports.default = void 0;
+
+function _chalk() {
+  const data = _interopRequireDefault(require('chalk'));
+
+  _chalk = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _emittery() {
+  const data = _interopRequireDefault(require('emittery'));
+
+  _emittery = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _throat() {
+  const data = _interopRequireDefault(require('throat'));
+
+  _throat = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestUtil() {
+  const data = require('jest-util');
+
+  _jestUtil = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestWorker() {
+  const data = require('jest-worker');
+
+  _jestWorker = function () {
+    return data;
+  };
+
+  return data;
+}
+
+var _runTest = _interopRequireDefault(require('./runTest'));
+
+var _types = require('./types');
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {default: obj};
+}
+
+function _classPrivateMethodInitSpec(obj, privateSet) {
+  _checkPrivateRedeclaration(obj, privateSet);
+  privateSet.add(obj);
+}
+
+function _classPrivateFieldInitSpec(obj, privateMap, value) {
+  _checkPrivateRedeclaration(obj, privateMap);
+  privateMap.set(obj, value);
+}
+
+function _checkPrivateRedeclaration(obj, privateCollection) {
+  if (privateCollection.has(obj)) {
+    throw new TypeError(
+      'Cannot initialize the same private elements twice on an object'
+    );
+  }
+}
+
+function _classPrivateFieldGet(receiver, privateMap) {
+  var descriptor = _classExtractFieldDescriptor(receiver, privateMap, 'get');
+  return _classApplyDescriptorGet(receiver, descriptor);
+}
+
+function _classExtractFieldDescriptor(receiver, privateMap, action) {
+  if (!privateMap.has(receiver)) {
+    throw new TypeError(
+      'attempted to ' + action + ' private field on non-instance'
+    );
+  }
+  return privateMap.get(receiver);
+}
+
+function _classApplyDescriptorGet(receiver, descriptor) {
+  if (descriptor.get) {
+    return descriptor.get.call(receiver);
+  }
+  return descriptor.value;
+}
+
+function _classPrivateMethodGet(receiver, privateSet, fn) {
+  if (!privateSet.has(receiver)) {
+    throw new TypeError('attempted to get private field on non-instance');
+  }
+  return fn;
+}
+
+const TEST_WORKER_PATH = require.resolve('./testWorker');
+
+var _eventEmitter = /*#__PURE__*/ new WeakMap();
+
+var _createInBandTestRun = /*#__PURE__*/ new WeakSet();
+
+var _createParallelTestRun = /*#__PURE__*/ new WeakSet();
+
+class TestRunner extends _types.EmittingTestRunner {
+  constructor(..._args) {
+    super(..._args);
+
+    _classPrivateMethodInitSpec(this, _createParallelTestRun);
+
+    _classPrivateMethodInitSpec(this, _createInBandTestRun);
+
+    _classPrivateFieldInitSpec(this, _eventEmitter, {
+      writable: true,
+      value: new (_emittery().default)()
+    });
+  }
+
+  async runTests(tests, watcher, options) {
+    return await (options.serial
+      ? _classPrivateMethodGet(
+          this,
+          _createInBandTestRun,
+          _createInBandTestRun2
+        ).call(this, tests, watcher)
+      : _classPrivateMethodGet(
+          this,
+          _createParallelTestRun,
+          _createParallelTestRun2
+        ).call(this, tests, watcher));
+  }
+
+  on(eventName, listener) {
+    return _classPrivateFieldGet(this, _eventEmitter).on(eventName, listener);
+  }
+}
+
+exports.default = TestRunner;
+
+async function _createInBandTestRun2(tests, watcher) {
+  process.env.JEST_WORKER_ID = '1';
+  const mutex = (0, _throat().default)(1);
+  return tests.reduce(
+    (promise, test) =>
+      mutex(() =>
+        promise
+          .then(async () => {
+            if (watcher.isInterrupted()) {
+              throw new CancelRun();
+            } // `deepCyclicCopy` used here to avoid mem-leak
+
+            const sendMessageToJest = (eventName, args) =>
+              _classPrivateFieldGet(this, _eventEmitter).emit(
+                eventName,
+                (0, _jestUtil().deepCyclicCopy)(args, {
+                  keepPrototype: false
+                })
+              );
+
+            await _classPrivateFieldGet(this, _eventEmitter).emit(
+              'test-file-start',
+              [test]
+            );
+            return (0, _runTest.default)(
+              test.path,
+              this._globalConfig,
+              test.context.config,
+              test.context.resolver,
+              this._context,
+              sendMessageToJest
+            );
+          })
+          .then(
+            result =>
+              _classPrivateFieldGet(this, _eventEmitter).emit(
+                'test-file-success',
+                [test, result]
+              ),
+            error =>
+              _classPrivateFieldGet(this, _eventEmitter).emit(
+                'test-file-failure',
+                [test, error]
+              )
+          )
+      ),
+    Promise.resolve()
+  );
+}
+
+async function _createParallelTestRun2(tests, watcher) {
+  const resolvers = new Map();
+
+  for (const test of tests) {
+    if (!resolvers.has(test.context.config.id)) {
+      resolvers.set(test.context.config.id, {
+        config: test.context.config,
+        serializableModuleMap: test.context.moduleMap.toJSON()
+      });
+    }
+  }
+
+  const worker = new (_jestWorker().Worker)(TEST_WORKER_PATH, {
+    exposedMethods: ['worker'],
+    // @ts-expect-error: option does not exist on the node 12 types
+    forkOptions: {
+      serialization: 'json',
+      stdio: 'pipe'
+    },
+    maxRetries: 3,
+    numWorkers: this._globalConfig.maxWorkers,
+    setupArgs: [
+      {
+        serializableResolvers: Array.from(resolvers.values())
+      }
+    ]
+  });
+  if (worker.getStdout()) worker.getStdout().pipe(process.stdout);
+  if (worker.getStderr()) worker.getStderr().pipe(process.stderr);
+  const mutex = (0, _throat().default)(this._globalConfig.maxWorkers); // Send test suites to workers continuously instead of all at once to track
+  // the start time of individual tests.
+
+  const runTestInWorker = test =>
+    mutex(async () => {
+      if (watcher.isInterrupted()) {
+        return Promise.reject();
+      }
+
+      await _classPrivateFieldGet(this, _eventEmitter).emit('test-file-start', [
+        test
+      ]);
+      const promise = worker.worker({
+        config: test.context.config,
+        context: {
+          ...this._context,
+          changedFiles:
+            this._context.changedFiles &&
+            Array.from(this._context.changedFiles),
+          sourcesRelatedToTestsInChangedFiles:
+            this._context.sourcesRelatedToTestsInChangedFiles &&
+            Array.from(this._context.sourcesRelatedToTestsInChangedFiles)
+        },
+        globalConfig: this._globalConfig,
+        path: test.path
+      });
+
+      if (promise.UNSTABLE_onCustomMessage) {
+        // TODO: Get appropriate type for `onCustomMessage`
+        promise.UNSTABLE_onCustomMessage(([event, payload]) =>
+          _classPrivateFieldGet(this, _eventEmitter).emit(event, payload)
+        );
+      }
+
+      return promise;
+    });
+
+  const onInterrupt = new Promise((_, reject) => {
+    watcher.on('change', state => {
+      if (state.interrupted) {
+        reject(new CancelRun());
+      }
+    });
+  });
+  const runAllTests = Promise.all(
+    tests.map(test =>
+      runTestInWorker(test).then(
+        result =>
+          _classPrivateFieldGet(this, _eventEmitter).emit('test-file-success', [
+            test,
+            result
+          ]),
+        error =>
+          _classPrivateFieldGet(this, _eventEmitter).emit('test-file-failure', [
+            test,
+            error
+          ])
+      )
+    )
+  );
+
+  const cleanup = async () => {
+    const {forceExited} = await worker.end();
+
+    if (forceExited) {
+      console.error(
+        _chalk().default.yellow(
+          'A worker process has failed to exit gracefully and has been force exited. ' +
+            'This is likely caused by tests leaking due to improper teardown. ' +
+            'Try running with --detectOpenHandles to find leaks. ' +
+            'Active timers can also cause this, ensure that .unref() was called on them.'
+        )
+      );
+    }
+  };
+
+  return Promise.race([runAllTests, onInterrupt]).then(cleanup, cleanup);
+}
+
+class CancelRun extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CancelRun';
+  }
+}

--- a/packages/jest-28/build/runTest.js
+++ b/packages/jest-28/build/runTest.js
@@ -1,0 +1,518 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.default = runTest;
+
+function _chalk() {
+  const data = _interopRequireDefault(require('chalk'));
+
+  _chalk = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function fs() {
+  const data = _interopRequireWildcard(require('graceful-fs'));
+
+  fs = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _sourceMapSupport() {
+  const data = _interopRequireDefault(require('source-map-support'));
+
+  _sourceMapSupport = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _console() {
+  const data = require('@jest/console');
+
+  _console = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _transform() {
+  const data = require('@jest/transform');
+
+  _transform = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function docblock() {
+  const data = _interopRequireWildcard(require('jest-docblock'));
+
+  docblock = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestLeakDetector() {
+  const data = _interopRequireDefault(require('jest-leak-detector'));
+
+  _jestLeakDetector = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestMessageUtil() {
+  const data = require('jest-message-util');
+
+  _jestMessageUtil = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestResolve() {
+  const data = require('jest-resolve');
+
+  _jestResolve = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestUtil() {
+  const data = require('jest-util');
+
+  _jestUtil = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _getRequireWildcardCache(nodeInterop) {
+  if (typeof WeakMap !== 'function') return null;
+  var cacheBabelInterop = new WeakMap();
+  var cacheNodeInterop = new WeakMap();
+  return (_getRequireWildcardCache = function (nodeInterop) {
+    return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+  })(nodeInterop);
+}
+
+function _interopRequireWildcard(obj, nodeInterop) {
+  if (!nodeInterop && obj && obj.__esModule) {
+    return obj;
+  }
+  if (obj === null || (typeof obj !== 'object' && typeof obj !== 'function')) {
+    return {default: obj};
+  }
+  var cache = _getRequireWildcardCache(nodeInterop);
+  if (cache && cache.has(obj)) {
+    return cache.get(obj);
+  }
+  var newObj = {};
+  var hasPropertyDescriptor =
+    Object.defineProperty && Object.getOwnPropertyDescriptor;
+  for (var key in obj) {
+    if (key !== 'default' && Object.prototype.hasOwnProperty.call(obj, key)) {
+      var desc = hasPropertyDescriptor
+        ? Object.getOwnPropertyDescriptor(obj, key)
+        : null;
+      if (desc && (desc.get || desc.set)) {
+        Object.defineProperty(newObj, key, desc);
+      } else {
+        newObj[key] = obj[key];
+      }
+    }
+  }
+  newObj.default = obj;
+  if (cache) {
+    cache.set(obj, newObj);
+  }
+  return newObj;
+}
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {default: obj};
+}
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+function freezeConsole(testConsole, config) {
+  // @ts-expect-error: `_log` is `private` - we should figure out some proper API here
+  testConsole._log = function fakeConsolePush(_type, message) {
+    const error = new (_jestUtil().ErrorWithStack)(
+      `${_chalk().default.red(
+        `${_chalk().default.bold(
+          'Cannot log after tests are done.'
+        )} Did you forget to wait for something async in your test?`
+      )}\nAttempted to log "${message}".`,
+      fakeConsolePush
+    );
+    const formattedError = (0, _jestMessageUtil().formatExecError)(
+      error,
+      config,
+      {
+        noStackTrace: false
+      },
+      undefined,
+      true
+    );
+    process.stderr.write(`\n${formattedError}\n`);
+    process.exitCode = 1;
+  };
+} // Keeping the core of "runTest" as a separate function (as "runTestInternal")
+// is key to be able to detect memory leaks. Since all variables are local to
+// the function, when "runTestInternal" finishes its execution, they can all be
+// freed, UNLESS something else is leaking them (and that's why we can detect
+// the leak!).
+//
+// If we had all the code in a single function, we should manually nullify all
+// references to verify if there is a leak, which is not maintainable and error
+// prone. That's why "runTestInternal" CANNOT be inlined inside "runTest".
+
+async function runTestInternal(
+  path,
+  globalConfig,
+  projectConfig,
+  resolver,
+  context,
+  sendMessageToJest
+) {
+  const testSource = fs().readFileSync(path, 'utf8');
+  const docblockPragmas = docblock().parse(docblock().extract(testSource));
+  const customEnvironment = docblockPragmas['jest-environment'];
+  let testEnvironment = projectConfig.testEnvironment;
+
+  if (customEnvironment) {
+    if (Array.isArray(customEnvironment)) {
+      throw new Error(
+        `You can only define a single test environment through docblocks, got "${customEnvironment.join(
+          ', '
+        )}"`
+      );
+    }
+
+    testEnvironment = (0, _jestResolve().resolveTestEnvironment)({
+      ...projectConfig,
+      requireResolveFunction: require.resolve,
+      testEnvironment: customEnvironment
+    });
+  }
+
+  const cacheFS = new Map([[path, testSource]]);
+  const transformer = await (0, _transform().createScriptTransformer)(
+    projectConfig,
+    cacheFS
+  );
+  const TestEnvironment = await transformer.requireAndTranspileModule(
+    testEnvironment
+  );
+  const testFramework = await transformer.requireAndTranspileModule(
+    process.env.JEST_JASMINE === '1'
+      ? require.resolve('jest-jasmine2')
+      : projectConfig.testRunner
+  );
+  const Runtime = (0, _jestUtil().interopRequireDefault)(
+    projectConfig.runtime
+      ? require(projectConfig.runtime)
+      : require('jest-runtime')
+  ).default;
+  const consoleOut = globalConfig.useStderr ? process.stderr : process.stdout;
+
+  const consoleFormatter = (type, message) =>
+    (0, _console().getConsoleOutput)(
+      // 4 = the console call is buried 4 stack frames deep
+      _console().BufferedConsole.write([], type, message, 4),
+      projectConfig,
+      globalConfig
+    );
+
+  let testConsole;
+
+  if (globalConfig.silent) {
+    testConsole = new (_console().NullConsole)(
+      consoleOut,
+      consoleOut,
+      consoleFormatter
+    );
+  } else if (globalConfig.verbose) {
+    testConsole = new (_console().CustomConsole)(
+      consoleOut,
+      consoleOut,
+      consoleFormatter
+    );
+  } else {
+    testConsole = new (_console().BufferedConsole)();
+  }
+
+  let extraTestEnvironmentOptions;
+  const docblockEnvironmentOptions =
+    docblockPragmas['jest-environment-options'];
+
+  if (typeof docblockEnvironmentOptions === 'string') {
+    extraTestEnvironmentOptions = JSON.parse(docblockEnvironmentOptions);
+  }
+
+  const environment = new TestEnvironment(
+    {
+      globalConfig,
+      projectConfig: extraTestEnvironmentOptions
+        ? {
+            ...projectConfig,
+            testEnvironmentOptions: {
+              ...projectConfig.testEnvironmentOptions,
+              ...extraTestEnvironmentOptions
+            }
+          }
+        : projectConfig
+    },
+    {
+      console: testConsole,
+      docblockPragmas,
+      testPath: path
+    }
+  );
+
+  if (typeof environment.getVmContext !== 'function') {
+    console.error(
+      `Test environment found at "${testEnvironment}" does not export a "getVmContext" method, which is mandatory from Jest 27. This method is a replacement for "runScript".`
+    );
+    process.exit(1);
+  }
+
+  const leakDetector = projectConfig.detectLeaks
+    ? new (_jestLeakDetector().default)(environment)
+    : null;
+  (0, _jestUtil().setGlobal)(environment.global, 'console', testConsole);
+  const runtime = new Runtime(
+    projectConfig,
+    environment,
+    resolver,
+    transformer,
+    cacheFS,
+    {
+      changedFiles: context.changedFiles,
+      collectCoverage: globalConfig.collectCoverage,
+      collectCoverageFrom: globalConfig.collectCoverageFrom,
+      collectCoverageOnlyFrom: globalConfig.collectCoverageOnlyFrom,
+      coverageProvider: globalConfig.coverageProvider,
+      sourcesRelatedToTestsInChangedFiles:
+        context.sourcesRelatedToTestsInChangedFiles
+    },
+    path
+  );
+  const start = Date.now();
+
+  for (const path of projectConfig.setupFiles) {
+    const esm = runtime.unstable_shouldLoadAsEsm(path);
+
+    if (esm) {
+      await runtime.unstable_importModule(path);
+    } else {
+      const setupFile = runtime.requireModule(path);
+
+      if (typeof setupFile === 'function') {
+        await setupFile();
+      }
+    }
+  }
+
+  const sourcemapOptions = {
+    environment: 'node',
+    handleUncaughtExceptions: false,
+    retrieveSourceMap: source => {
+      var _runtime$getSourceMap;
+
+      const sourceMapSource =
+        (_runtime$getSourceMap = runtime.getSourceMaps()) === null ||
+        _runtime$getSourceMap === void 0
+          ? void 0
+          : _runtime$getSourceMap.get(source);
+
+      if (sourceMapSource) {
+        try {
+          return {
+            map: JSON.parse(fs().readFileSync(sourceMapSource, 'utf8')),
+            url: source
+          };
+        } catch {}
+      }
+
+      return null;
+    }
+  }; // For tests
+
+  runtime
+    .requireInternalModule(require.resolve('source-map-support'))
+    .install(sourcemapOptions); // For runtime errors
+
+  _sourceMapSupport().default.install(sourcemapOptions);
+
+  if (
+    environment.global &&
+    environment.global.process &&
+    environment.global.process.exit
+  ) {
+    const realExit = environment.global.process.exit;
+
+    environment.global.process.exit = function exit(...args) {
+      const error = new (_jestUtil().ErrorWithStack)(
+        `process.exit called with "${args.join(', ')}"`,
+        exit
+      );
+      const formattedError = (0, _jestMessageUtil().formatExecError)(
+        error,
+        projectConfig,
+        {
+          noStackTrace: false
+        },
+        undefined,
+        true
+      );
+      process.stderr.write(formattedError);
+      return realExit(...args);
+    };
+  } // if we don't have `getVmContext` on the env skip coverage
+
+  const collectV8Coverage =
+    globalConfig.coverageProvider === 'v8' &&
+    typeof environment.getVmContext === 'function';
+
+  try {
+    await environment.setup();
+    let result;
+
+    try {
+      if (collectV8Coverage) {
+        await runtime.collectV8Coverage();
+      }
+
+      result = await testFramework(
+        globalConfig,
+        projectConfig,
+        environment,
+        runtime,
+        path,
+        sendMessageToJest
+      );
+    } catch (err) {
+      // Access stack before uninstalling sourcemaps
+      err.stack;
+      throw err;
+    } finally {
+      if (collectV8Coverage) {
+        await runtime.stopCollectingV8Coverage();
+      }
+    }
+
+    freezeConsole(testConsole, projectConfig);
+    const testCount =
+      result.numPassingTests +
+      result.numFailingTests +
+      result.numPendingTests +
+      result.numTodoTests;
+    const end = Date.now();
+    const testRuntime = end - start;
+    result.perfStats = {
+      end,
+      runtime: testRuntime,
+      slow: testRuntime / 1000 > projectConfig.slowTestThreshold,
+      start
+    };
+    result.testFilePath = path;
+    result.console = testConsole.getBuffer();
+    result.skipped = testCount === result.numPendingTests;
+    result.displayName = projectConfig.displayName;
+    const coverage = runtime.getAllCoverageInfoCopy();
+
+    if (coverage) {
+      const coverageKeys = Object.keys(coverage);
+
+      if (coverageKeys.length) {
+        result.coverage = coverage;
+      }
+    }
+
+    if (collectV8Coverage) {
+      const v8Coverage = runtime.getAllV8CoverageInfoCopy();
+
+      if (v8Coverage && v8Coverage.length > 0) {
+        result.v8Coverage = v8Coverage;
+      }
+    }
+
+    if (globalConfig.logHeapUsage) {
+      var _globalThis$gc;
+
+      // @ts-expect-error
+      (_globalThis$gc = globalThis.gc) === null || _globalThis$gc === void 0
+        ? void 0
+        : _globalThis$gc.call(globalThis);
+      result.memoryUsage = process.memoryUsage().heapUsed;
+    } // Delay the resolution to allow log messages to be output.
+
+    return new Promise(resolve => {
+      setImmediate(() =>
+        resolve({
+          leakDetector,
+          result
+        })
+      );
+    });
+  } finally {
+    runtime.teardown();
+    await environment.teardown();
+
+    _sourceMapSupport().default.resetRetrieveHandlers();
+  }
+}
+
+async function runTest(
+  path,
+  globalConfig,
+  config,
+  resolver,
+  context,
+  sendMessageToJest
+) {
+  const {leakDetector, result} = await runTestInternal(
+    path,
+    globalConfig,
+    config,
+    resolver,
+    context,
+    sendMessageToJest
+  );
+
+  if (leakDetector) {
+    // We wanna allow a tiny but time to pass to allow last-minute cleanup
+    await new Promise(resolve => setTimeout(resolve, 100)); // Resolve leak detector, outside the "runTestInternal" closure.
+
+    result.leaks = await leakDetector.isLeaking();
+  } else {
+    result.leaks = false;
+  }
+
+  return result;
+}

--- a/packages/jest-28/build/testWorker.js
+++ b/packages/jest-28/build/testWorker.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const v8 = require('v8');
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.setup = setup;
+exports.worker = worker;
+
+function _exit() {
+  const data = _interopRequireDefault(require('exit'));
+
+  _exit = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestHasteMap() {
+  const data = _interopRequireDefault(require('jest-haste-map'));
+
+  _jestHasteMap = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestMessageUtil() {
+  const data = require('jest-message-util');
+
+  _jestMessageUtil = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestRuntime() {
+  const data = _interopRequireDefault(require('jest-runtime'));
+
+  _jestRuntime = function () {
+    return data;
+  };
+
+  return data;
+}
+
+function _jestWorker() {
+  const data = require('jest-worker');
+
+  _jestWorker = function () {
+    return data;
+  };
+
+  return data;
+}
+
+var _runTest = _interopRequireDefault(require('./runTest'));
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {default: obj};
+}
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+// Make sure uncaught errors are logged before we exit.
+process.on('uncaughtException', err => {
+  console.error(err.stack);
+  (0, _exit().default)(1);
+});
+
+const formatError = error => {
+  if (typeof error === 'string') {
+    const {message, stack} = (0, _jestMessageUtil().separateMessageFromStack)(
+      error
+    );
+    return {
+      message,
+      stack,
+      type: 'Error'
+    };
+  }
+
+  return {
+    code: error.code || undefined,
+    message: error.message,
+    stack: error.stack,
+    type: 'Error'
+  };
+};
+
+const resolvers = new Map();
+
+const getResolver = config => {
+  const resolver = resolvers.get(config.id);
+
+  if (!resolver) {
+    throw new Error(`Cannot find resolver for: ${config.id}`);
+  }
+
+  return resolver;
+};
+
+function setup(setupData) {
+  // Module maps that will be needed for the test runs are passed.
+  for (const {
+    config,
+    serializableModuleMap
+  } of setupData.serializableResolvers) {
+    const moduleMap = _jestHasteMap()
+      .default.getStatic(config)
+      .getModuleMapFromJSON(serializableModuleMap);
+
+    resolvers.set(
+      config.id,
+      _jestRuntime().default.createResolver(config, moduleMap)
+    );
+  }
+}
+
+const sendMessageToJest = (eventName, args) => {
+  (0, _jestWorker().messageParent)([eventName, args]);
+};
+
+async function worker({config, globalConfig, path, context}) {
+  const heap = v8.getHeapStatistics();
+
+  if (heap.total_heap_size / heap.heap_size_limit > 0.8) {
+    (0, _exit().default)(1);
+  }
+
+  try {
+    return await (0, _runTest.default)(
+      path,
+      globalConfig,
+      config,
+      getResolver(config),
+      {
+        ...context,
+        changedFiles: context.changedFiles && new Set(context.changedFiles),
+        sourcesRelatedToTestsInChangedFiles:
+          context.sourcesRelatedToTestsInChangedFiles &&
+          new Set(context.sourcesRelatedToTestsInChangedFiles)
+      },
+      sendMessageToJest
+    );
+  } catch (error) {
+    throw formatError(error);
+  }
+}

--- a/packages/jest-28/build/types.js
+++ b/packages/jest-28/build/types.js
@@ -1,0 +1,34 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.EmittingTestRunner = exports.CallbackTestRunner = void 0;
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+class BaseTestRunner {
+  isSerial;
+  supportsEventEmitters;
+
+  constructor(_globalConfig, _context) {
+    this._globalConfig = _globalConfig;
+    this._context = _context;
+  }
+}
+
+class CallbackTestRunner extends BaseTestRunner {
+  supportsEventEmitters = false;
+}
+
+exports.CallbackTestRunner = CallbackTestRunner;
+
+class EmittingTestRunner extends BaseTestRunner {
+  supportsEventEmitters = true;
+}
+
+exports.EmittingTestRunner = EmittingTestRunner;

--- a/packages/jest-28/package.json
+++ b/packages/jest-28/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "jest-runner-iansu",
+  "version": "28.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iansu/jest-runner-iansu.git",
+    "directory": "packages/jest-28"
+  },
+  "license": "MIT",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "@jest/console": "^28.0.0",
+    "@jest/environment": "^28.0.0",
+    "@jest/test-result": "^28.0.0",
+    "@jest/transform": "^28.0.0",
+    "@jest/types": "^28.0.0",
+    "@types/node": "*",
+    "chalk": "^4.0.0",
+    "emittery": "^0.10.2",
+    "graceful-fs": "^4.2.9",
+    "jest-docblock": "^28.0.0",
+    "jest-environment-node": "^28.0.0",
+    "jest-haste-map": "^28.0.0",
+    "jest-leak-detector": "^28.0.0",
+    "jest-message-util": "^28.0.0",
+    "jest-resolve": "^28.0.0",
+    "jest-runtime": "^28.0.0",
+    "jest-util": "^28.0.0",
+    "jest-watcher": "^28.0.0",
+    "jest-worker": "^28.0.0",
+    "source-map-support": "0.5.13",
+    "throat": "^6.0.1"
+  },
+  "devDependencies": {
+    "@tsd/typescript": "~4.6.2",
+    "@types/exit": "^0.1.30",
+    "@types/graceful-fs": "^4.1.3",
+    "@types/source-map-support": "^0.5.0",
+    "jest-jasmine2": "^28.0.0",
+    "tsd-lite": "^0.5.1"
+  },
+  "engines": {
+    "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "8f9b812faf8e4d241d560a8574f0c6ed20a89365"
+}


### PR DESCRIPTION
Add the patched runner for Jest 28.

This is the exact same code that's used in the other runners so I think it will work but I have to test it in a project still.